### PR TITLE
Add Read the Docs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,11 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,3 +9,6 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ release = '0.0.1'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -130,9 +130,6 @@ html_theme = "sphinx_rtd_theme"
 # further.  For a list of options available for each theme, see the
 # documentation.
 #html_theme_options = {}
-
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,6 @@
+sphinx_rtd_theme==3.1.0
+mock==5.2.0
+pandas==3.0.3
+requests==2.34.2
+tabulate==0.10.0
+pytz==2026.2


### PR DESCRIPTION
Update configuration to get Read the Docs building the documentation again.

The way Read the Docs operates had changed over time and the process had stopped building the documentation as originally set up.

This fixes #7. 